### PR TITLE
Copds 1112 multiple requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## To Do
+
 - `JobList`, `ProcessList` as iterators
 - Naming consistency: processing -> retrieve
 - Remove unused `Remote.build_status_info` method
@@ -17,19 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.4.0] - 2023-06-14
+
 ### Added
+
 - Support for multiple requests to the CADS API client [COPDS-1112](https://jira.ecmwf.int/browse/COPDS-1112)
 - `Remote.response` property added
 - `target_folder` parameter added to `Results.download`
 
 ### Changed
+
 - `Remote.wait_on_result` returns status
 
 ### Changed
+
 ### Fixed
+
 ### Removed
 
-
-[Unreleased]: https://github.com/ecmwf-projects/cads-api-client/compare/v0.4.0...main
 [0.4.0]: https://github.com/ecmwf-projects/cads-api-client/compare/v0.3.0...v0.4.0
-
+[unreleased]: https://github.com/ecmwf-projects/cads-api-client/compare/v0.4.0...main

--- a/cads_api_client/catalogue.py
+++ b/cads_api_client/catalogue.py
@@ -1,12 +1,11 @@
 import datetime
+import os.path
 from typing import Any, Dict, List, Optional
 
 import attrs
 import requests
-import os.path
 
 from . import processing
-from . import multi_retrieve
 
 
 @attrs.define
@@ -64,24 +63,32 @@ class Collection(processing.ApiResponse):
         return remote.download(target, retry_options=retry_options)
 
     def multi_retrieve(
-            self,
-            target: Optional[str] = None,
-            retry_options: Dict[str, Any] = {},
-            accepted_licences: List[Dict[str, Any]] = [],
-            requests: List[Dict] | Dict = [],
-            max_updates: int = 10,
-            max_downloads: int = 2,
+        self,
+        target: Optional[str] = None,
+        retry_options: Dict[str, Any] = {},
+        accepted_licences: List[Dict[str, Any]] = [],
+        requests: List[Dict] | Dict = [],
+        max_updates: int = 10,
+        max_downloads: int = 2,
     ):  # TODO in retrieve (composite pattern)
-
         if target and len(requests) > 1 and not os.path.isdir(target):
-            raise ValueError(f"The target parameter path must be a directory ({target} given instead)")
+            raise ValueError(
+                f"The target parameter path must be a directory ({target} given instead)"
+            )
 
         for request in requests:
-            request.update({'accepted_licences': accepted_licences})
+            request.update({"accepted_licences": accepted_licences})
 
-        return multi_retrieve.multi_retrieve(collection=self, requests=requests,
-                                             target=target, retry_options=retry_options,
-                                             max_updates=max_updates, max_downloads=max_downloads)
+        from .multi_retrieve import multi_retrieve
+
+        return multi_retrieve(
+            collection=self,
+            requests=requests,
+            target=target,
+            retry_options=retry_options,
+            max_updates=max_updates,
+            max_downloads=max_downloads,
+        )
 
 
 class Catalogue:

--- a/cads_api_client/processing.py
+++ b/cads_api_client/processing.py
@@ -160,7 +160,7 @@ class Remote:
 
     @property
     def status(self) -> str:
-        return self.response.json()["status"]   # type: ignore
+        return self.response.json()["status"]  # type: ignore
 
     def _robust_status(self, retry_options: Dict[str, Any] = {}) -> str:
         # TODO: cache responses for a timeout (possibly reported nby the server)
@@ -172,10 +172,13 @@ class Remote:
         return json["status"]  # type: ignore
         # return self._robust_response(retry_options=retry_options).json()["status"]  # type: ignore
 
-    def wait_on_result(self, retry_options: Dict[str, Any] = {}) -> None:
+    def wait_on_result(self, retry_options: Dict[str, Any] = {}) -> str:
         """
-        Poll periodically the current request for its status (accepted, running, successful, failed) until it has been
-        processed (successful, failed). The wait time increases automatically from 1 second up to ``sleep_max``.
+        Wait job until finished.
+
+        Poll periodically the current request for its status (accepted, running, successful, failed) until
+        it has been processed (successful, failed). The wait time increases automatically from 1 second up
+        to ``sleep_max``.
 
         Parameters
         ----------
@@ -183,7 +186,7 @@ class Remote:
 
         Returns
         -------
-
+        Job status (successful, failed)
         """
         sleep = 1.0
         last_status = self._robust_status(retry_options=retry_options)
@@ -300,7 +303,7 @@ class Results(ApiResponse):
     def download(
         self,
         target: Optional[str] = None,
-        target_folder: str = '.',
+        target_folder: str = ".",
         timeout: int = 60,
         retry_options: Dict[str, Any] = {},
     ) -> str:

--- a/notebooks/cads_api_multi_request_test.py
+++ b/notebooks/cads_api_multi_request_test.py
@@ -16,15 +16,17 @@
 # %load_ext autoreload
 # %autoreload 2
 
-import json
 import logging
 import os
 
 from cads_api_client import ApiClient
+
 # from cads_api_client.multi_retrieve import multi_retrieve
 
 # env vars
-CADS_API_ROOT_URL = os.getenv("CADS_API_ROOT_URL", "http://cds2-dev.copernicus-climate.eu/api")
+CADS_API_ROOT_URL = os.getenv(
+    "CADS_API_ROOT_URL", "http://cds2-dev.copernicus-climate.eu/api"
+)
 
 # logging
 format = "%(asctime)s - %(levelname)s - %(name)s - %(threadName)s - %(message)s"
@@ -42,32 +44,46 @@ MAX_UPDATES = 5
 # init
 client = ApiClient(url=CADS_API_ROOT_URL, key="00112233-4455-6677-c899-aabbccddeeff")
 collection = client.collection("reanalysis-era5-pressure-levels")
-accepted_licences=[{"id": "licence-to-use-copernicus-products", "revision": 12}]
+accepted_licences = [{"id": "licence-to-use-copernicus-products", "revision": 12}]
 requests = [
-    dict(product_type="reanalysis",
-         variable="temperature",
-         pressure_level="1",
-         year=str(year),
-         month=['01'],
-         day=['01'],
-         time="06:00",
-         # accepted_licences=[{"id": "licence-to-use-copernicus-products", "revision": 12}]
-         ) for year in range(2014, 2024)]
+    dict(
+        product_type="reanalysis",
+        variable="temperature",
+        pressure_level="1",
+        year=str(year),
+        month=["01"],
+        day=["01"],
+        time="06:00",
+        # accepted_licences=[{"id": "licence-to-use-copernicus-products", "revision": 12}]
+    )
+    for year in range(2014, 2024)
+]
 
-print(f"Requests: {len(requests)}\n"\
-      f"Concurrent updates: {MAX_UPDATES}\n"\
-      f"Concurrent downloads: {MAX_DOWNLOADS}")
+print(
+    f"Requests: {len(requests)}\n"
+    f"Concurrent updates: {MAX_UPDATES}\n"
+    f"Concurrent downloads: {MAX_DOWNLOADS}"
+)
 
 client = ApiClient(url=CADS_API_ROOT_URL, key="00112233-4455-6677-c899-aabbccddeeff")
 collection = client.collection("reanalysis-era5-pressure-levels")
 target = "/tmp"
-results = collection.multi_retrieve(requests=requests, accepted_licences=accepted_licences, 
-                                    target=target, max_updates=10, max_downloads=2)
+results = collection.multi_retrieve(
+    requests=requests,
+    accepted_licences=accepted_licences,
+    target=target,
+    max_updates=10,
+    max_downloads=2,
+)
 
 
 print("YEAR | " + "{:>20}".format("HASH") + " | PATH")
 for request_hash, result in results.items():
-    request, job, download = result.get("request"), result.get("job"), result.get("download", {})
+    request, job, download = (
+        result.get("request"),
+        result.get("job"),
+        result.get("download", {}),
+    )
     print(f"{request['year']} | {request_hash:20} | {download.get('path')}")
 
 results


### PR DESCRIPTION
### Added

- Support for multiple requests to the CADS API client [COPDS-1112](https://jira.ecmwf.int/browse/COPDS-1112)
- `Remote.response` property added
- `target_folder` parameter added to `Results.download`

### Changed

- `Remote.wait_on_result` returns status
