### PR TITLE
Remove accepted_licences from retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Draft Python API:
 >>> collection.end_datetime()
 datetime.datetime(2022, 7, 20, 23, 0)
 >>> remote = client.retrieve(
-...     accepted_licences=[{"id": "licence-to-use-copernicus-products", "revision": 12}],
 ...     collection_id="reanalysis-era5-pressure-levels",
 ...     product_type="reanalysis",
 ...     variable="temperature",
@@ -33,7 +32,6 @@ datetime.datetime(2022, 7, 20, 23, 0)
 ...     target="tmp1-era5.grib",
 ... )  # blocks
 >>> remote = collection.submit(
-...     accepted_licences=[{"id": "licence-to-use-copernicus-products", "revision": 12}],
 ...     variable="temperature",
 ...     product_type="reanalysis",
 ...     year="2021",
@@ -67,8 +65,7 @@ Advanced usage:
 ...         "day": "03",
 ...         "time": "00:00",
 ...         "level": "1000",
-...     },
-...     accepted_licences=[{"id": "licence-to-use-copernicus-products", "revision": 12}],
+...     }
 ... )  # doesn't block
 >>> remote = status_info.make_remote()
 >>> remote_url = remote.url

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ CADS API Python client
 The `ApiClient` needs the `url` to the API root and a valid API `key` to access protected resources.
 You can also set the `CADS_API_URL` and `CADS_API_KEY` environment variables.
 
-It is possible (but not recommended) to use the API key of the anonymous user
-`00112233-4455-6677-c899-aabbccddeeff`. This is used in anonymous tests and
+It is possible (but not recommended) to use the API key of one of the test users,
+`00000000-0000-4000-a000-000000000000`. This is used in anonymous tests and
 it is designed to be the least performant option to access the system.
 
 Draft Python API:
 
 ```python
 >>> import os
->>> cads_api_key = os.getenv("CADS_API_KEY", "00112233-4455-6677-c899-aabbccddeeff")
+>>> cads_api_key = os.getenv("CADS_API_KEY", "00000000-0000-4000-a000-000000000000")
 
 >>> import cads_api_client
 >>> client = cads_api_client.ApiClient(cads_api_key)

--- a/cads_api_client/api_client.py
+++ b/cads_api_client/api_client.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import attrs
 import requests

--- a/cads_api_client/api_client.py
+++ b/cads_api_client/api_client.py
@@ -58,14 +58,12 @@ class ApiClient:
         collection_id: str,
         target: Optional[str] = None,
         retry_options: Dict[str, Any] = {},
-        accepted_licences: List[Dict[str, Any]] = [],
         **request: Any,
     ) -> str:
         collection = self.collection(collection_id)
         return collection.retrieve(
             target,
             retry_options=retry_options,
-            accepted_licences=accepted_licences,
             **request,
         )
 

--- a/cads_api_client/catalogue.py
+++ b/cads_api_client/catalogue.py
@@ -42,23 +42,18 @@ class Collection(processing.ApiResponse):
             "get", url, headers=self.headers, session=self.session
         )
 
-    def submit(
-        self, accepted_licences: List[Dict[str, Any]] = [], **request: Any
-    ) -> processing.Remote:
+    def submit(self, **request: Any) -> processing.Remote:
         retrieve_process = self.retrieve_process()
-        status_info = retrieve_process.execute(
-            inputs=request, accepted_licences=accepted_licences, session=self.session
-        )
+        status_info = retrieve_process.execute(inputs=request, session=self.session)
         return status_info.make_remote()
 
     def retrieve(
         self,
         target: Optional[str] = None,
         retry_options: Dict[str, Any] = {},
-        accepted_licences: List[Dict[str, Any]] = [],
         **request: Any,
     ) -> str:
-        remote = self.submit(accepted_licences=accepted_licences, **request)
+        remote = self.submit(**request)
         return remote.download(target, retry_options=retry_options)
 
 

--- a/cads_api_client/processing.py
+++ b/cads_api_client/processing.py
@@ -114,13 +114,12 @@ class Process(ApiResponse):
     def execute(
         self,
         inputs: Dict[str, Any],
-        accepted_licences: List[Dict[str, Any]] = [],
         retry_options: Dict[str, Any] = {},
         **kwargs: Any,
     ) -> StatusInfo:
         assert "json" not in kwargs
         url = f"{self.response.request.url}/execute"
-        json = {"inputs": inputs, "acceptedLicences": accepted_licences}
+        json = {"inputs": inputs}
         return StatusInfo.from_request(
             "post",
             url,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ def api_root_url() -> str:
 
 @pytest.fixture
 def api_key() -> str:
-    # default to anonymous access for tests
-    return os.getenv("CADS_API_KEY") or "00112233-4455-6677-c899-aabbccddeeff"
+    # default to test user 1
+    return os.getenv("CADS_API_KEY") or "00000000-0000-4000-a000-000000000000"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ def api_key() -> str:
 
 
 @pytest.fixture
+def api_key_anon() -> str:
+    return "00112233-4455-6677-c899-aabbccddeeff"
+
+
+@pytest.fixture
 def request_year() -> str:
     return os.environ.get("CADS_TEST_YEAR", "2016")
 

--- a/tests/integration_test_20_processing.py
+++ b/tests/integration_test_20_processing.py
@@ -49,10 +49,10 @@ def test_validate_constraints(api_root_url: str) -> None:
 
 
 def test_collection_missing_licence(
-    api_root_url: str, api_key: str, request_year: str
+    api_root_url: str, api_key_anon: str, request_year: str
 ) -> None:
     collection_id = "test-adaptor-mars"
-    headers = {"PRIVATE-TOKEN": api_key}
+    headers = {"PRIVATE-TOKEN": api_key_anon}
     proc = processing.Processing(f"{api_root_url}/retrieve", headers=headers)
     process = proc.process(collection_id)
 

--- a/tests/integration_test_30_remote.py
+++ b/tests/integration_test_30_remote.py
@@ -54,16 +54,12 @@ def test_collection_retrieve_with_url_cds_adaptor(
 ) -> None:
     collection_id = "test-adaptor-url"
     headers = {"PRIVATE-TOKEN": api_key}
-    accepted_licences: list[dict[str, Any]] = [
-        {"id": "licence-to-use-copernicus-products", "revision": 12}
-    ]
 
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
     dataset = cat.collection(collection_id)
     target = str(tmpdir.join("wfde1.zip"))
 
     res = dataset.retrieve(
-        accepted_licences=accepted_licences,
         variable="grid_point_altitude",
         reference_dataset="cru",
         version="2.1",
@@ -77,7 +73,6 @@ def test_collection_retrieve_with_url_cds_adaptor(
     target = str(tmpdir.join("wfde2.zip"))
 
     res = dataset.retrieve(
-        accepted_licences=accepted_licences,
         variable="grid_point_altitude",
         reference_dataset="cru",
         version="2.1",
@@ -94,16 +89,12 @@ def test_collection_retrieve_with_direct_mars_cds_adaptor(
 ) -> None:
     collection_id = "test-adaptor-direct-mars"
     headers = {"PRIVATE-TOKEN": api_key}
-    accepted_licences: list[dict[str, Any]] = [
-        {"id": "licence-to-use-copernicus-products", "revision": 12}
-    ]
 
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
     dataset = cat.collection(collection_id)
     target = str(tmpdir.join("era5-complete.grib"))
 
     res = dataset.retrieve(
-        accepted_licences=accepted_licences,
         levelist=1,
         dataset="reanalysis",
         time="00:00:00",
@@ -126,16 +117,12 @@ def test_collection_retrieve_with_mars_cds_adaptor(
 ) -> None:
     collection_id = "test-adaptor-mars"
     headers = {"PRIVATE-TOKEN": api_key}
-    accepted_licences: list[dict[str, Any]] = [
-        {"id": "licence-to-use-copernicus-products", "revision": 12}
-    ]
 
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
     dataset = cat.collection(collection_id)
     target = str(tmpdir.join("era5.grib"))
 
     res = dataset.retrieve(
-        accepted_licences=accepted_licences,
         product_type="reanalysis",
         variable="2m_temperature",
         year=request_year,
@@ -155,16 +142,12 @@ def test_collection_retrieve_with_legacy_cds_adaptor(
 ) -> None:
     collection_id = "test-adaptor-legacy"
     headers = {"PRIVATE-TOKEN": api_key}
-    accepted_licences: list[dict[str, Any]] = [
-        {"id": "licence-to-use-copernicus-products", "revision": 12}
-    ]
 
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
     dataset = cat.collection(collection_id)
     target = str(tmpdir.join("era5.grib"))
 
     res = dataset.retrieve(
-        accepted_licences=accepted_licences,
         product_type="reanalysis",
         variable="temperature",
         year=request_year,

--- a/tests/integration_test_30_remote.py
+++ b/tests/integration_test_30_remote.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import py
 
 from cads_api_client import catalogue, processing

--- a/tests/test_10_processing.py
+++ b/tests/test_10_processing.py
@@ -257,7 +257,6 @@ def responses_add() -> None:
             json_params_matcher(
                 {
                     "inputs": {"variable": "temperature", "year": "2022"},
-                    "acceptedLicences": [],
                 }
             )
         ],


### PR DESCRIPTION
This PR:
- removes the possibility to accept licences in the context of processes submission via the `accepted_licences` key
- changes default user for integration test to test user 1 (instead of anonymous user)

Blocked by:
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/163

**WARNING**: with this modification in place, anonymous user cannot currently submit jobs.