### PR TITLE
More integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ docs-build:
 # DO NOT EDIT ABOVE THIS LINE, ADD COMMANDS BELOW
 
 integration-tests:
-	python -m pytest -vv --cov=. --cov-report=$(COV_REPORT) tests/integration*.py
+	python -m pytest -vv --cov=. --cov-report=$(COV_REPORT) tests/integration_test_60*.py
 
 doc-tests:
 	python -m pytest -vv --doctest-glob='*.md' README.md

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ docs-build:
 # DO NOT EDIT ABOVE THIS LINE, ADD COMMANDS BELOW
 
 integration-tests:
-	python -m pytest -vv --cov=. --cov-report=$(COV_REPORT) tests/integration_test_60*.py
+	python -m pytest -vv --cov=. --cov-report=$(COV_REPORT) tests/integration*.py
 
 doc-tests:
 	python -m pytest -vv --doctest-glob='*.md' README.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,15 +52,15 @@ def temp_environ() -> Any:
 
 
 @pytest.fixture(autouse=True)
-def skip_if_entry_not_available(request) -> None:
+def skip_if_entry_not_available(request, api_root_url:str, api_key: str) -> None:
     from cads_api_client import catalogue
 
-    cat = catalogue.Catalogue(f"{api_root_url()}/catalogue", headers={"PRIVATE-TOKEN": api_key(api_root_url())})
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
     if request.node.get_closest_marker('skip_missing_entry') is not None:
         entry = request.node.get_closest_marker('skip_missing_entry').args[0]
         # colls = cat.collections().collection_ids()
         try:
             assert entry in cat.collections(params=dict(q=entry)).collection_ids()
         except Exception:
-            pytest.skip(f"{entry} not available in catalogue: {api_root_url()} {api_key(api_root_url())}")
+            pytest.skip(f"{entry} not available in catalogue: {api_root_url} {api_key}")
    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,9 @@ def skip_if_entry_not_available(request) -> None:
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
     if request.node.get_closest_marker('skip_missing_entry') is not None:
         entry = request.node.get_closest_marker('skip_missing_entry').args[0]
-        colls = cat.collections().collection_ids()
+        # colls = cat.collections().collection_ids()
         try:
             assert entry in cat.collections(params=dict(q=entry)).collection_ids()
         except Exception:
-            pytest.skip(f"{entry} not available in catalogue: {colls}")
+            pytest.skip(f"{entry} not available in catalogue: {api_root_url} {api_key}")
    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,9 +56,10 @@ def skip_if_entry_not_available(request) -> None:
     from cads_api_client import catalogue
 
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
-    entry = request.node.get_closest_marker('skip_missing_entry').args[0]
-    try:
-        assert entry in cat.collections(params=dict(q=entry)).collection_ids()
-    except Exception:
-        pytest.skip(f"{entry} not available in catalogue")
+    if request.node.get_closest_marker('skip_missing_entry') is not None:
+        entry = request.node.get_closest_marker('skip_missing_entry').args[0]
+        try:
+            assert entry in cat.collections(params=dict(q=entry)).collection_ids()
+        except Exception:
+            pytest.skip(f"{entry} not available in catalogue")
    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,12 +51,12 @@ def temp_environ() -> Any:
     os.environ.update(old_environ)
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def skip_if_entry_not_available(request) -> None:
     from cads_api_client import catalogue
 
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
-    entry = request.node.get_closest_marker('entry').args[0]
+    entry = request.node.get_closest_marker('skip_missing_entry').args[0]
     try:
         assert entry in cat.collections(params=dict(q=entry)).collection_ids()
     except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,5 +62,5 @@ def skip_if_entry_not_available(request, api_root_url:str, api_key: str) -> None
         try:
             assert entry in cat.collections(params=dict(q=entry)).collection_ids()
         except Exception:
-            pytest.skip(f"{entry} not available in catalogue: {api_root_url} {api_key}")
+            pytest.skip(f"{entry} not available in catalogue")
    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def temp_environ() -> Any:
     os.environ.update(old_environ)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def skip_if_entry_not_available(request) -> None:
     from cads_api_client import catalogue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,9 @@ def skip_if_entry_not_available(request) -> None:
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
     if request.node.get_closest_marker('skip_missing_entry') is not None:
         entry = request.node.get_closest_marker('skip_missing_entry').args[0]
+        colls = cat.collections().collection_ids()
         try:
             assert entry in cat.collections(params=dict(q=entry)).collection_ids()
         except Exception:
-            pytest.skip(f"{entry} not available in catalogue")
+            pytest.skip(f"{entry} not available in catalogue: {colls}")
    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,15 +52,16 @@ def temp_environ() -> Any:
 
 
 @pytest.fixture(autouse=True)
-def skip_if_entry_not_available(request, api_root_url:str, api_key: str) -> None:
+def skip_if_entry_not_available(request, api_root_url: str, api_key: str) -> None:
     from cads_api_client import catalogue
 
-    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
-    if request.node.get_closest_marker('skip_missing_entry') is not None:
-        entry = request.node.get_closest_marker('skip_missing_entry').args[0]
+    cat = catalogue.Catalogue(
+        f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key}
+    )
+    if request.node.get_closest_marker("skip_missing_entry") is not None:
+        entry = request.node.get_closest_marker("skip_missing_entry").args[0]
         # colls = cat.collections().collection_ids()
         try:
             assert entry in cat.collections(params=dict(q=entry)).collection_ids()
         except Exception:
             pytest.skip(f"{entry} not available in catalogue")
-   

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,16 @@ def temp_environ() -> Any:
 
     os.environ.clear()
     os.environ.update(old_environ)
+
+
+@pytest.fixture(autouse=True)
+def skip_if_entry_not_available(request) -> None:
+    from cads_api_client import catalogue
+
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
+    entry = request.node.get_closest_marker('entry').args[0]
+    try:
+        assert entry in cat.collections(params=dict(q=entry)).collection_ids()
+    except Exception:
+        pytest.skip(f"{entry} not available in catalogue")
+   

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,12 +55,12 @@ def temp_environ() -> Any:
 def skip_if_entry_not_available(request) -> None:
     from cads_api_client import catalogue
 
-    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers={"PRIVATE-TOKEN": api_key})
+    cat = catalogue.Catalogue(f"{api_root_url()}/catalogue", headers={"PRIVATE-TOKEN": api_key(api_root_url())})
     if request.node.get_closest_marker('skip_missing_entry') is not None:
         entry = request.node.get_closest_marker('skip_missing_entry').args[0]
         # colls = cat.collections().collection_ids()
         try:
             assert entry in cat.collections(params=dict(q=entry)).collection_ids()
         except Exception:
-            pytest.skip(f"{entry} not available in catalogue: {api_root_url} {api_key}")
+            pytest.skip(f"{entry} not available in catalogue: {api_root_url()} {api_key(api_root_url())}")
    

--- a/tests/integration_test_30_remote.py
+++ b/tests/integration_test_30_remote.py
@@ -99,7 +99,7 @@ def test_collection_retrieve_with_url_cds_adaptor_area_selection(
         version="2.1",
         target=target,
         retry_options={"maximum_tries": 0},
-        area=[50,0,40,10]
+        area=[50, 0, 40, 10],
     )
 
     assert isinstance(res, str)

--- a/tests/integration_test_30_remote.py
+++ b/tests/integration_test_30_remote.py
@@ -136,6 +136,33 @@ def test_collection_retrieve_with_mars_cds_adaptor(
     assert res.endswith(target)
 
 
+
+def test_collection_retrieve_with_mars_cds_adaptor_netcdf(
+    api_root_url: str, api_key: str, request_year: str, tmpdir: py.path.local
+) -> None:
+    collection_id = "test-adaptor-mars"
+    headers = {"PRIVATE-TOKEN": api_key}
+
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
+    dataset = cat.collection(collection_id)
+    target = str(tmpdir.join("era5.grib"))
+
+    res = dataset.retrieve(
+        product_type="reanalysis",
+        variable="2m_temperature",
+        year=request_year,
+        month="01",
+        day="02",
+        time="00:00",
+        target=target,
+        retry_options={"maximum_tries": 0},
+        format="netcdf",
+    )
+
+    assert isinstance(res, str)
+    assert res.endswith(target)
+
+
 @pytest.mark.skip(reason="discontinued adaptor")
 def test_collection_retrieve_with_legacy_cds_adaptor(
     api_root_url: str, api_key: str, request_year: str, tmpdir: py.path.local

--- a/tests/integration_test_30_remote.py
+++ b/tests/integration_test_30_remote.py
@@ -136,7 +136,6 @@ def test_collection_retrieve_with_mars_cds_adaptor(
     assert res.endswith(target)
 
 
-
 def test_collection_retrieve_with_mars_cds_adaptor_netcdf(
     api_root_url: str, api_key: str, request_year: str, tmpdir: py.path.local
 ) -> None:
@@ -145,7 +144,7 @@ def test_collection_retrieve_with_mars_cds_adaptor_netcdf(
 
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
     dataset = cat.collection(collection_id)
-    target = str(tmpdir.join("era5.grib"))
+    target = str(tmpdir.join("test.result"))
 
     res = dataset.retrieve(
         product_type="reanalysis",

--- a/tests/integration_test_30_remote.py
+++ b/tests/integration_test_30_remote.py
@@ -83,6 +83,29 @@ def test_collection_retrieve_with_url_cds_adaptor(
     assert res.endswith(target)
 
 
+def test_collection_retrieve_with_url_cds_adaptor_area_selection(
+    api_root_url: str, api_key: str, request_year: str, tmpdir: py.path.local
+) -> None:
+    collection_id = "test-adaptor-url"
+    headers = {"PRIVATE-TOKEN": api_key}
+
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
+    dataset = cat.collection(collection_id)
+    target = str(tmpdir.join("wfde1.zip"))
+
+    res = dataset.retrieve(
+        variable="grid_point_altitude",
+        reference_dataset="cru",
+        version="2.1",
+        target=target,
+        retry_options={"maximum_tries": 0},
+        area=[50,0,40,10]
+    )
+
+    assert isinstance(res, str)
+    assert res.endswith(target)
+
+
 def test_collection_retrieve_with_direct_mars_cds_adaptor(
     api_root_url: str, api_key: str, request_year: str, tmpdir: py.path.local
 ) -> None:

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -73,3 +73,36 @@ def test_reanalysis_era5_single_levels(
     assert isinstance(res, str)
     assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
 
+
+
+@pytest.mark.skip_missing_entry("seasonal-original-single-levels")
+@pytest.mark.parametrize("data_format", ("grib", "netcdf"))
+def test_reanalysis_era5_single_levels(
+    api_root_url: str, api_key: str, tmpdir: py.path.local,
+    data_format: str
+) -> None:
+    os.chdir(tmpdir)
+
+    headers = {"PRIVATE-TOKEN": api_key}
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
+
+    collection_id = "seasonal-original-single-levels"
+    dataset = cat.collection(collection_id)
+    request = {
+        'originating_centre': 'ukmo',
+        'system': '12',
+        'variable': ['2m_dewpoint_temperature'],
+        'year': ['2015'],
+        'month': ['02'],
+        'day': ['09'],
+        'leadtime_hour': ['390'],
+        "data_foramt": data_format,
+        "_timestamp": str(time.time())
+    }
+    res = dataset.retrieve(
+        **request
+    )
+
+    assert isinstance(res, str)
+    assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
+

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -1,0 +1,39 @@
+import os
+import py
+import pytest
+
+from cads_api_client import catalogue
+
+DATA_FORMAT_EXTENTIONS = {
+    "grib": ".grib",
+    "netcdf": ".nc",
+}
+
+@pytest.mark.parametrize("data_format", ("grib", "netcdf"))
+def test_real_collection(
+    api_root_url: str, api_key: str, tmpdir: py.path.local,
+    data_format: str
+) -> None:
+    os.chdir(tmpdir)
+
+    headers = {"PRIVATE-TOKEN": api_key}
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
+
+
+    collection_id = "reanalysis-era5-single-levels"
+    dataset = cat.collection(collection_id)
+    request = {
+        "variable": "2m_temperature",
+        "year": "2020",
+        "month": "01",
+        "day": "01",
+        "time": "00:00",
+        "data_format": data_format,
+    }
+    res = dataset.retrieve(
+        **request
+    )
+
+    assert isinstance(res, str)
+    assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
+

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -40,7 +40,7 @@ def test_reanalysis_era5_single_levels(
 
 
 
-@pytest.mark.skip_if_entry_not_available("cams-global-atmospheric-composition-aliens")
+@pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-aliens")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
 def test_cams_global_atmospheric_composition_forecasts(
     api_root_url: str, api_key: str, tmpdir: py.path.local,

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -54,10 +54,15 @@ def test_cams_global_atmospheric_composition_forecasts(
     collection_id = "cams-global-atmospheric-composition-forecasts"
     dataset = cat.collection(collection_id)
     request = {
-        'variable': ['total_column_glyoxal','total_column_dimethyl_sulfide'],
-        'date': "2020-01-01/2020-01-02",
-        'time': '00:00', 'leadtime_hour': '0', 'type': 'forecast',
-        'data_format': data_format}
+        'variable': [
+            'total_column_dimethyl_sulfide', 'total_column_glyoxal',
+        ],
+        'date': '2024-01-02',
+        'time': '00:00',
+        'leadtime_hour': '0',
+        'type': 'forecast',
+        'data_format': data_format
+    }
     res = dataset.retrieve(
         **request
     )

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -40,7 +40,7 @@ def test_reanalysis_era5_single_levels(
 
 
 
-@pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-aliens")
+@pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-forecasts")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
 def test_cams_global_atmospheric_composition_forecasts(
     api_root_url: str, api_key: str, tmpdir: py.path.local,

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -24,6 +24,7 @@ def test_real_collection(
     dataset = cat.collection(collection_id)
     request = {
         "variable": "2m_temperature",
+        "product_type": "reanalysis",
         "year": "2020",
         "month": "01",
         "day": "01",

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -40,7 +40,7 @@ def test_reanalysis_era5_single_levels(
 
 
 
-@pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-aliens")
+@pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-forecasts")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
 def test_cams_global_atmospheric_composition_forecasts(
     api_root_url: str, api_key: str, tmpdir: py.path.local,
@@ -54,14 +54,10 @@ def test_cams_global_atmospheric_composition_forecasts(
     collection_id = "reanalysis-era5-single-levels"
     dataset = cat.collection(collection_id)
     request = {
-        "variable": "2m_temperature",
-        "product_type": "reanalysis",
-        "year": "2020",
-        "month": "01",
-        "day": "01",
-        "time": "00:00",
-        "data_format": data_format,
-    }
+        'variable': ['total_column_glyoxal','total_column_dimethyl_sulfide'],
+        'date': "2020-01-01/2020-01-02",
+        'time': '00:00', 'leadtime_hour': '0', 'type': 'forecast',
+        'data_format': data_format}
     res = dataset.retrieve(
         **request
     )

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -1,7 +1,8 @@
 import os
+import time
+
 import py
 import pytest
-import time
 
 from cads_api_client import catalogue
 
@@ -14,8 +15,7 @@ DATA_FORMAT_EXTENTIONS = {
 @pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-forecasts")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
 def test_cams_global_atmospheric_composition_forecasts(
-    api_root_url: str, api_key: str, tmpdir: py.path.local,
-    data_format: str
+    api_root_url: str, api_key: str, tmpdir: py.path.local, data_format: str
 ) -> None:
     os.chdir(tmpdir)
 
@@ -25,19 +25,18 @@ def test_cams_global_atmospheric_composition_forecasts(
     collection_id = "cams-global-atmospheric-composition-forecasts"
     dataset = cat.collection(collection_id)
     request = {
-        'variable': [
-            'total_column_dimethyl_sulfide', 'total_column_glyoxal',
+        "variable": [
+            "total_column_dimethyl_sulfide",
+            "total_column_glyoxal",
         ],
-        'date': '2024-01-02',
-        'time': '00:00',
-        'leadtime_hour': '0',
-        'type': 'forecast',
-        'data_format': data_format,
-        "_timestamp": str(time.time())
+        "date": "2024-01-02",
+        "time": "00:00",
+        "leadtime_hour": "0",
+        "type": "forecast",
+        "data_format": data_format,
+        "_timestamp": str(time.time()),
     }
-    res = dataset.retrieve(
-        **request
-    )
+    res = dataset.retrieve(**request)
 
     assert isinstance(res, str)
     assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
@@ -46,8 +45,7 @@ def test_cams_global_atmospheric_composition_forecasts(
 @pytest.mark.skip_missing_entry("reanalysis-era5-single-levels")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
 def test_reanalysis_era5_single_levels(
-    api_root_url: str, api_key: str, tmpdir: py.path.local,
-    data_format: str
+    api_root_url: str, api_key: str, tmpdir: py.path.local, data_format: str
 ) -> None:
     os.chdir(tmpdir)
 
@@ -64,22 +62,18 @@ def test_reanalysis_era5_single_levels(
         "day": "01",
         "time": "00:00",
         "data_format": data_format,
-        "_timestamp": str(time.time())
+        "_timestamp": str(time.time()),
     }
-    res = dataset.retrieve(
-        **request
-    )
+    res = dataset.retrieve(**request)
 
     assert isinstance(res, str)
     assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
 
 
-
 @pytest.mark.skip_missing_entry("seasonal-original-single-levels")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
-def test_reanalysis_era5_single_levels(
-    api_root_url: str, api_key: str, tmpdir: py.path.local,
-    data_format: str
+def test_seasonal_original_era5_single_levels(
+    api_root_url: str, api_key: str, tmpdir: py.path.local, data_format: str
 ) -> None:
     os.chdir(tmpdir)
 
@@ -89,20 +83,17 @@ def test_reanalysis_era5_single_levels(
     collection_id = "seasonal-original-single-levels"
     dataset = cat.collection(collection_id)
     request = {
-        'originating_centre': 'ukmo',
-        'system': '12',
-        'variable': ['2m_dewpoint_temperature'],
-        'year': ['2015'],
-        'month': ['02'],
-        'day': ['09'],
-        'leadtime_hour': ['390'],
-        "data_foramt": data_format,
-        "_timestamp": str(time.time())
+        "originating_centre": "ukmo",
+        "system": "12",
+        "variable": ["2m_dewpoint_temperature"],
+        "year": ["2015"],
+        "month": ["02"],
+        "day": ["09"],
+        "leadtime_hour": ["390"],
+        "data_format": data_format,
+        "_timestamp": str(time.time()),
     }
-    res = dataset.retrieve(
-        **request
-    )
+    res = dataset.retrieve(**request)
 
     assert isinstance(res, str)
     assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
-

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -40,7 +40,7 @@ def test_reanalysis_era5_single_levels(
 
 
 
-@pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-forecasts")
+@pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-aliens")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
 def test_cams_global_atmospheric_composition_forecasts(
     api_root_url: str, api_key: str, tmpdir: py.path.local,

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -40,7 +40,7 @@ def test_reanalysis_era5_single_levels(
 
 
 
-@pytest.mark.skip_if_entry_not_available("cams-global-atmospheric-composition-forecasts")
+@pytest.mark.skip_if_entry_not_available("cams-global-atmospheric-composition-aliens")
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
 def test_cams_global_atmospheric_composition_forecasts(
     api_root_url: str, api_key: str, tmpdir: py.path.local,

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -9,8 +9,9 @@ DATA_FORMAT_EXTENTIONS = {
     "netcdf": ".nc",
 }
 
+
 @pytest.mark.parametrize("data_format", ("grib", "netcdf"))
-def test_real_collection(
+def test_reanalysis_era5_single_levels(
     api_root_url: str, api_key: str, tmpdir: py.path.local,
     data_format: str
 ) -> None:
@@ -18,7 +19,6 @@ def test_real_collection(
 
     headers = {"PRIVATE-TOKEN": api_key}
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
-
 
     collection_id = "reanalysis-era5-single-levels"
     dataset = cat.collection(collection_id)
@@ -38,3 +38,33 @@ def test_real_collection(
     assert isinstance(res, str)
     assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
 
+
+
+@pytest.mark.skip_if_entry_not_available("cams-global-atmospheric-composition-forecasts")
+@pytest.mark.parametrize("data_format", ("grib", "netcdf"))
+def test_cams_global_atmospheric_composition_forecasts(
+    api_root_url: str, api_key: str, tmpdir: py.path.local,
+    data_format: str
+) -> None:
+    os.chdir(tmpdir)
+
+    headers = {"PRIVATE-TOKEN": api_key}
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
+
+    collection_id = "reanalysis-era5-single-levels"
+    dataset = cat.collection(collection_id)
+    request = {
+        "variable": "2m_temperature",
+        "product_type": "reanalysis",
+        "year": "2020",
+        "month": "01",
+        "day": "01",
+        "time": "00:00",
+        "data_format": data_format,
+    }
+    res = dataset.retrieve(
+        **request
+    )
+
+    assert isinstance(res, str)
+    assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -1,6 +1,7 @@
 import os
 import py
 import pytest
+import time
 
 from cads_api_client import catalogue
 
@@ -8,36 +9,6 @@ DATA_FORMAT_EXTENTIONS = {
     "grib": ".grib",
     "netcdf": ".nc",
 }
-
-
-@pytest.mark.parametrize("data_format", ("grib", "netcdf"))
-def test_reanalysis_era5_single_levels(
-    api_root_url: str, api_key: str, tmpdir: py.path.local,
-    data_format: str
-) -> None:
-    os.chdir(tmpdir)
-
-    headers = {"PRIVATE-TOKEN": api_key}
-    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
-
-    collection_id = "reanalysis-era5-single-levels"
-    dataset = cat.collection(collection_id)
-    request = {
-        "variable": "2m_temperature",
-        "product_type": "reanalysis",
-        "year": "2020",
-        "month": "01",
-        "day": "01",
-        "time": "00:00",
-        "data_format": data_format,
-    }
-    res = dataset.retrieve(
-        **request
-    )
-
-    assert isinstance(res, str)
-    assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
-
 
 
 @pytest.mark.skip_missing_entry("cams-global-atmospheric-composition-forecasts")
@@ -61,7 +32,8 @@ def test_cams_global_atmospheric_composition_forecasts(
         'time': '00:00',
         'leadtime_hour': '0',
         'type': 'forecast',
-        'data_format': data_format
+        'data_format': data_format,
+        "_timestamp": str(time.time())
     }
     res = dataset.retrieve(
         **request
@@ -69,3 +41,35 @@ def test_cams_global_atmospheric_composition_forecasts(
 
     assert isinstance(res, str)
     assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
+
+
+@pytest.mark.skip_missing_entry("reanalysis-era5-single-levels")
+@pytest.mark.parametrize("data_format", ("grib", "netcdf"))
+def test_reanalysis_era5_single_levels(
+    api_root_url: str, api_key: str, tmpdir: py.path.local,
+    data_format: str
+) -> None:
+    os.chdir(tmpdir)
+
+    headers = {"PRIVATE-TOKEN": api_key}
+    cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
+
+    collection_id = "reanalysis-era5-single-levels"
+    dataset = cat.collection(collection_id)
+    request = {
+        "variable": "2m_temperature",
+        "product_type": "reanalysis",
+        "year": "2020",
+        "month": "01",
+        "day": "01",
+        "time": "00:00",
+        "data_format": data_format,
+        "_timestamp": str(time.time())
+    }
+    res = dataset.retrieve(
+        **request
+    )
+
+    assert isinstance(res, str)
+    assert res.endswith(DATA_FORMAT_EXTENTIONS[data_format])
+

--- a/tests/integration_test_60_real_datasets.py
+++ b/tests/integration_test_60_real_datasets.py
@@ -51,7 +51,7 @@ def test_cams_global_atmospheric_composition_forecasts(
     headers = {"PRIVATE-TOKEN": api_key}
     cat = catalogue.Catalogue(f"{api_root_url}/catalogue", headers=headers)
 
-    collection_id = "reanalysis-era5-single-levels"
+    collection_id = "cams-global-atmospheric-composition-forecasts"
     dataset = cat.collection(collection_id)
     request = {
         'variable': ['total_column_glyoxal','total_column_dimethyl_sulfide'],


### PR DESCRIPTION
New tests:
- Test URL dataset with area selection
- Test MARS dataset with netCDF conversion
- Real MARS datasets with and without netcdf conversion:
  - reanalysis-era5-single-levels
  - seasonal-original-single-levels
  - cams-global-atmospheric-composition-forecasts

Also includes a fixture for checking that the dataset exists in the catalogue for testing. This is particularly useful for the CAMS dataset, which will not be visible in a default deployment. Therefore, it is recommended that dev stacks have all datasets visible via the api-url to ensure that all tests are executed.