### PR TITLE
Fix extracting end_datetime from STAC collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Draft Python API:
 >>> import cads_api_client
 >>> client = cads_api_client.ApiClient(cads_api_key)
 >>> collection = client.collection("reanalysis-era5-pressure-levels")
->>> collection.end_datetime()
-datetime.datetime(2022, 7, 20, 23, 0)
+>>> collection.end_datetime
+datetime.datetime(...)
 >>> remote = client.retrieve(
 ...     collection_id="reanalysis-era5-pressure-levels",
 ...     product_type="reanalysis",

--- a/cads_api_client/catalogue.py
+++ b/cads_api_client/catalogue.py
@@ -30,12 +30,18 @@ class Collections(processing.ApiResponse):
 class Collection(processing.ApiResponse):
     headers: Dict[str, Any] = {}
 
+    @property
+    def temporal_interval(self) -> tuple[Any, Any]:
+        ((begin, end),) = self.json["extent"]["temporal"]["interval"]
+        return (begin, end)
+
+    @property
+    def begin_datetime(self) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(self.temporal_interval[0])
+
+    @property
     def end_datetime(self) -> datetime.datetime:
-        try:
-            end = self.json["extent"]["temporal"]["interval"][0][1]
-        except Exception:
-            end = "2022-07-20T23:00:00"
-        return datetime.datetime.fromisoformat(end)
+        return datetime.datetime.fromisoformat(self.temporal_interval[1])
 
     @property
     def id(self) -> str:

--- a/cads_api_client/catalogue.py
+++ b/cads_api_client/catalogue.py
@@ -31,9 +31,9 @@ class Collection(processing.ApiResponse):
     headers: Dict[str, Any] = {}
 
     @property
-    def temporal_interval(self) -> tuple[Any, Any]:
+    def temporal_interval(self) -> tuple[str, str]:
         ((begin, end),) = self.json["extent"]["temporal"]["interval"]
-        return (begin, end)
+        return (str(begin), str(end))
 
     @property
     def begin_datetime(self) -> datetime.datetime:

--- a/cads_api_client/catalogue.py
+++ b/cads_api_client/catalogue.py
@@ -32,7 +32,7 @@ class Collection(processing.ApiResponse):
 
     def end_datetime(self) -> datetime.datetime:
         try:
-            end = self.json["extent"]["temporal"]["interval"][1]
+            end = self.json["extent"]["temporal"]["interval"][0][1]
         except Exception:
             end = "2022-07-20T23:00:00"
         return datetime.datetime.fromisoformat(end)

--- a/tests/integration_test_10_catalogue.py
+++ b/tests/integration_test_10_catalogue.py
@@ -43,3 +43,5 @@ def test_collection(api_root_url: str) -> None:
     assert res.id == collection_id
     assert "links" in res.json
     assert isinstance(res.json["links"], list)
+    assert res.begin_datetime.isoformat() == "1959-01-01T00:00:00+00:00"
+    assert res.end_datetime.isoformat() == "2023-05-09T00:00:00+00:00"


### PR DESCRIPTION
Hi, end_datetime always fails because it tries to extract from an invalid array index. STAC Collection temporal extent is an array of multiple intervals. See https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#temporal-extent-object

Btw, what's the relation between cdsapi (which is recommended officially) and cads-api-client (which is used inside)? Is cads-api-client going to be the new recommended client after completing the switch to the new CDS/ADS-Beta?